### PR TITLE
Add M-X prefix option

### DIFF
--- a/mykie.el
+++ b/mykie.el
@@ -49,7 +49,8 @@
       (or (and (bolp)        :C-u&bolp)
           (and (eolp)        :C-u&eolp)))
     (mykie:get-C-u-keyword)
-    (when current-prefix-arg :C-u) ; Use :C-u if C-u*X isn't exists
+    (when (listp current-prefix-arg) :C-u) ; Use :C-u if C-u*X isn't exists
+    (mykie:get-M-number-keyword)
     (when (mykie:repeat-p)   :repeat)
     (when (minibufferp)      :minibuff)
     (when (bobp)             :bobp)
@@ -122,6 +123,11 @@ Example
 (defun mykie:repeat-p ()
   (equal this-command last-command))
 
+(defun mykie:get-M-number-keyword ()
+  "Return :M-X(X is number)."
+  (if (numberp current-prefix-arg)
+      (intern (concat ":M-" (number-to-string current-prefix-arg)))))
+
 (defun mykie:get-C-u-times ()
   (setq mykie:C-u-num (truncate (log (or (car current-prefix-arg) 1) 4)))
   mykie:C-u-num)
@@ -130,11 +136,12 @@ Example
 
 (defun mykie:get-C-u-keyword ()
   "Return :C-u or :C-u*X(X is replaced to C-u's pushed times)."
-  (lexical-let
-      ((times (mykie:get-C-u-times)))
-    (if (= 1 times)
-        :C-u
-      (intern (concat ":C-u*" (number-to-string times))))))
+  (when (listp current-prefix-arg)
+    (lexical-let
+        ((times (mykie:get-C-u-times)))
+      (if (= 1 times)
+          :C-u
+        (intern (concat ":C-u*" (number-to-string times)))))))
 
 (defun mykie:init (args)
   (when (plist-get args :use-C-u-num)


### PR DESCRIPTION
This is another way of utilizing prefix command.
Although I'm not sure everyone often do `M-2` or `C-u 2` before execute any command.
If this addition doesn't make any trouble, please merge it.

Example.

```
(defun mykie-M-number-test ()
  (interactive)
  (mykie
   :default            '(message "default")
   :M-1                '(message "M number 1")
   :M-2                '(message "M number 2")
   :M-3                '(message "M number 3")
   :M-12               '(message "M number 12")
   :C-u                '(message "C-u 1 time")
   :C-u*2              '(message "C-u 2 time")
   ))
(global-set-key (kbd "M-o") 'mykie-M-number-test)
```
