### PR TITLE
0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,13 @@ before_install:
   - curl -fsSkL https://gist.github.com/rejeep/7736123/raw | sh
   - export PATH="/home/travis/.cask/bin:$PATH"
   - export PATH="/home/travis/.evm/bin:$PATH"
-  - evm install $EVM_EMACS --use
+  - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  global:
-    - CURL=curl -fsSkL --retry 9 --retry-delay 9
-  matrix:
-    # - EVM_EMACS=emacs-23.4-bin
-    # - EVM_EMACS=emacs-24.1-bin
-    # - EVM_EMACS=emacs-24.2-bin
-    - EVM_EMACS=emacs-24.3-bin
-install:
-  - if ! test $EVM_EMACS = emacs-24.3-bin; then
-      $CURL https://raw.github.com/ohler/ert/fb3c278d/lisp/emacs-lisp/ert.el -o ert.el;
-      $CURL https://raw.github.com/emacsmirror/cl-lib/master/cl-lib.el -o cl-lib.el;
-    fi
+  # - EVM_EMACS=emacs-24.1-bin
+  # - EVM_EMACS=emacs-24.2-bin
+  - EVM_EMACS=emacs-24.3-bin
+  - EVM_EMACS=emacs-24.4-bin
 script:
   - emacs --version
   - make test

--- a/Cask
+++ b/Cask
@@ -6,4 +6,5 @@
 
 (development
   ;; Unit test libraries
-  (depends-on "ert-runner"))
+  (depends-on "ert-runner")
+  (depends-on "cl-lib"))

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 [![Build Status](https://travis-ci.org/yuutayamada/mykie-el.png?branch=master)](https://travis-ci.org/yuutayamada/mykie-el)
-[![Gittip](http://img.shields.io/gittip/yuutayamada.png)](https://www.gittip.com/yuutayamada)
 
 # Mykie.el | Command multiplexer
 
 Do you have enough keybinds in Emacs?
 No? Then this program strong helps you to add other functions to
 **a single** keybind.
+
+## Requirement
+This package needs Emacs 24.3 or higher.
 
 ## Installation
 
@@ -14,7 +16,7 @@ You can install from MELPA by M-x package-install RET mykie.
 ## Note
 
 From v0.2.0, quote is not needed anymore when you register keybinds.
-So if you are already using old mykie.el, please delete needless
+So if you ware already using old mykie.el, please delete needless
 quotes before you use new mykie.el.
 Also condition's form was changed from v0.2.0.
 See Customizing section if you want to add specific condition.
@@ -185,6 +187,32 @@ You can specify below forms.
    :region  query-replace-regexp)
 ```
 
+### Shorthand for key binding and unbinding
+mykie's :default keywords is redundant to specify just one function.
+If you don't specify :default keyword and the function is only one,
+you can use shorthand of `mykie:set-keys` function to register and
+un-register multiple keybinds.
+
+Registering keybinds is like this:
+```lisp
+(mykie:set-keys nil ; <- global-map
+  "C-0" (message "foo") ; Eval as S-expression
+  "C-1" emacs-version   ; Eval as command
+  "C-2"
+  :default (message "You can combine :default keyword as well.")
+  :C-u     (message "You can combine other keyword as well.")
+  )
+```
+
+Un-registering keybinds is like this:
+```lisp
+(mykie:set-keys nil ; <- global-map
+  "C-0" "C-1" ; <- those keys are unregistered
+  ;; You can register keybinds in this function
+  "C-3" :default (message "Hello")
+  )
+```
+
 ### Key Definition
 
 There are four patterns to specify `mykie` keybinds.
@@ -286,9 +314,7 @@ To avoid major-mode key overriding, you can specify specific modes like this:
 ```
 
 You can use below configuration to avoid overriding major-mode key.
-This way can ignore overriding major-mode key only specific keybind.
-So you can't play tetris if current major-mode that you specified to
-:ignore-major-modes has same keybind.
+This way ignores overriding major-mode keys.
 
 ```lisp
 (setq mykie:use-major-mode-key-override 'both)
@@ -301,7 +327,7 @@ So you can't play tetris if current major-mode that you specified to
   :ignore-major-modes (diff-minor-mode))
 ```
 
-You can specify specific mode by your hand.
+You can specify specific mode.
 
 ```lisp
 (setq mykie:use-major-mode-key-override nil)
@@ -313,7 +339,6 @@ You can specify specific mode by your hand.
 
 Below example is common keywords.
 You can make sure available full keywords at `mykie:conditions` variable.
-(mykie.el is using **state** as terminology of condition's keyword)
 
 -   Normal Keywords Example
 ```lisp
@@ -439,11 +464,11 @@ There is a similar command that do first command and then wait user input.
 
 Above command do newline-and-indent and then wait user input.
 
-## Customizing(WIP)
+## Customizing own condition
 
 You can change or attach `mykie`s conditions.
 
-Here is an example to attach conditions.
+Here is an example to attach your customized conditions.
 
 ```lisp
 (setq mykie:normal-conditions
@@ -457,12 +482,6 @@ Here is an example to attach conditions.
                                              (`"24.3.1" :24.3.1)
                                              (`"24.5.1" :24.5.1))))))
 ```
-
-## Known issues
-Mykie.el can't use with multiple-cursors.el.
-To avoid this problem, mykie use global-map's key before load
-mykie.el.
-Pull request is welcome:)
 
 ## Contributor(s)
 Here's a [list](https://github.com/yuutayamada/mykie-el/contributors)

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -1,4 +1,4 @@
-;;; mykie.el --- Command multiplexer: Register multiple functions to a keybind
+;;; mykie.el --- Command multiplexer: Register multiple functions to a keybind -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013 by Yuta Yamada
 

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -172,14 +172,21 @@ To change this variable use `add-to-list'.")
 
 (defvar mykie:make-funcname-function
   (lambda (args keymap key &optional keymap-name)
-    (intern (format
-             "mykie:%s:%s:%s"
-             (or keymap-name "")
-             (replace-regexp-in-string " " "_" (key-description key))
-             ;; Some programs check command name by
-             ;; (string-match "self-insert-command" command-name)
-             (if (eq (funcall mykie:get-default-function args) 'self-insert-command)
-                 "self-insert-command" "key")))))
+    (let ((keyname (replace-regexp-in-string " " "_" (key-description key))))
+      (intern (if (equal global-map keymap)
+                  (format "mykie:%s:%s:%s"
+                          (or keymap-name "")
+                          keyname
+                          ;; Some programs check command name by
+                          ;; (string-match "self-insert-command" command-name)
+                          (if (eq (funcall mykie:get-default-function args)
+                                  'self-insert-command)
+                              "self-insert-command" "key"))
+                ;; Inject function name of :default function for
+                ;; other function describing library.
+                (format "mykie:%s:%s:%s" (plist-get args :default)
+                        (or keymap-name "")
+                        keyname))))))
 
 (defvar mykie:use-original-key-predicate
   (lambda ()

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -632,10 +632,18 @@ Otherwise return KW-AND-CONDITION's first element."
       (before (run-hooks 'mykie:region-before-init-hook))
       (after  (run-hooks 'mykie:region-after-init-hook)))))
 
+(defun mykie:kbd (key)
+  (kbd key))
+
+;; TODO: Fix this to work around in old version Emacs
+(when (version< emacs-version "24.3")
+  (defadvice mykie:kbd (around macro->function activate)
+    (setq ad-return-value (apply (macroexpand (list 'kbd (ad-get-arg 0)))))))
+
 (defun mykie:format-key (key)
   (cl-typecase key
     (vector key)
-    (string (kbd key))
+    (string (mykie:kbd key))
     (t (error "Invalid key"))))
 
 (defmacro mykie:define-key (keymap key &rest args)

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -170,23 +170,24 @@ To change this variable use `add-to-list'.")
              if (member (nth i args) mykie:default-keywords)
              do (cl-return (plist-get args (car it))))))
 
+(defvar mykie:funcname-style nil
+  "Style of `mykie:make-funcname-function'.
+You can specify 'old to make old style funcname.")
+
 (defvar mykie:make-funcname-function
-  (lambda (args keymap key &optional keymap-name)
-    (let ((keyname (replace-regexp-in-string " " "_" (key-description key))))
-      (intern (if (equal global-map keymap)
-                  (format "mykie:%s:%s:%s"
-                          (or keymap-name "")
-                          keyname
-                          ;; Some programs check command name by
-                          ;; (string-match "self-insert-command" command-name)
-                          (if (eq (funcall mykie:get-default-function args)
-                                  'self-insert-command)
-                              "self-insert-command" "key"))
-                ;; Inject function name of :default function for
-                ;; other function describing library.
-                (format "mykie:%s:%s:%s" (plist-get args :default)
-                        (or keymap-name "")
-                        keyname))))))
+  (lambda (args _keymap key &optional keymap-name)
+    (let ((keyname (replace-regexp-in-string " " "_" (key-description key)))
+          (default-func (funcall mykie:get-default-function args)))
+      (intern (format "mykie:%s:%s:%s"
+                      (or keymap-name "") keyname
+                      (cl-case mykie:funcname-style
+                        (old
+                         (if (eq default-func 'self-insert-command)
+                             "self-insert-command"
+                           "key"))
+                        (t (if (listp default-func)
+                               "anonymous-func"
+                             default-func))))))))
 
 (defvar mykie:use-original-key-predicate
   (lambda ()

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -189,10 +189,7 @@ You can specify 'old to make old style funcname.")
                                "anonymous-func"
                              default-func))))))))
 
-(defvar mykie:use-original-key-predicate
-  (lambda ()
-    (cond ((bound-and-true-p multiple-cursors-mode) t)
-          (t nil)))
+(defvar mykie:use-original-key-predicate nil
   "Predicate whether you use original keybind before load mykie.el.")
 
 (defconst mykie:get-fallback-function
@@ -200,7 +197,8 @@ You can specify 'old to make old style funcname.")
     (cond ((mykie:ignore-mode-p)
            ;; Return default function
            (funcall mykie:get-default-function args))
-          ((funcall mykie:use-original-key-predicate)
+          ((and mykie:use-original-key-predicate
+                (funcall mykie:use-original-key-predicate))
            (let ((func (lookup-key
                         (bound-and-true-p mykie:original-map)
                         (car (plist-get args :key-info)))))
@@ -304,7 +302,7 @@ Example
      (funcall 'call-interactively func))
     (function (funcall func))
     (list     (funcall 'eval `(progn ,func))))
-  (unless (ido-active)
+  (unless (or (ido-active) (bound-and-true-p multiple-cursors-mode))
     (run-hooks 'post-command-hook))
   (mykie:run-hook 'after))
 

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -207,7 +207,7 @@ To change this variable use `add-to-list'.")
        (and current-prefix-arg
             (not (equal '(4) current-prefix-arg))))
       (`mykie:prefix-arg-conditions current-prefix-arg)
-      (condition-name t)))
+      (t t)))
   "Pre-check condition depending on CONDITION-NAME before check the
 CONDITION-NAME's condition. If you add conditions to
 `mykie:group-conditions', then you can add your precheck condition by

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -790,20 +790,12 @@ Examples:
        (keymap-sym (cdr pair))
        (set-key
         (lambda (key-and-prop &optional keymap-name keymap)
-          (let*
-              ((key (car key-and-prop))
-               (property
-                (mykie:parse-parenthesized-syntax (cdr key-and-prop))))
+          (let ((key (car key-and-prop))
+                (property (mykie:format-property order (cdr key-and-prop))))
             (cl-case order
               (with-self-key
                (mykie:define-key-with-self-key-core key property))
-              (t ; apply defining function without :default
-               (when (not (or (member :default property)
-                              (member t property)))
-                 (cl-case (length property)
-                   (1 (setq property (append '(:default) property)))
-                   (2 (setq property (append '(:default) `(,property))))))
-               (mykie:define-key-core keymap-name keymap key property))))))
+              (t (mykie:define-key-core keymap-name keymap key property))))))
        (set-keys
         (lambda ()
           (cl-loop with last = (1- (length args))
@@ -822,6 +814,17 @@ Examples:
                         (funcall set-key key-and-prop keymap-name keymap)
                         (setq key-and-prop nil))))))
     (funcall set-keys)))
+
+(defun mykie:format-property (order property)
+  (mykie:parse-parenthesized-syntax
+   (if (eq order 'with-self-key)
+       property
+     (if (not (or (member :default property)
+                  (member t property)))
+         (cl-case (length property)
+           (1 (append '(:default) property))
+           (2 (append '(:default) `(,property))))
+       property))))
 
 (defun mykie:parse-parenthesized-syntax (args)
   (cl-typecase (car args)

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -659,7 +659,6 @@ Example:
         (let* ((args (append (mykie:parse-parenthesized-syntax args)
                              (unless (plist-get args :key-info)
                                `(:key-info (,key . ,keymap-name)))))
-               ;; Workaround: Assign command name
                (sym (funcall mykie:make-funcname-function
                              args keymap key keymap-name)))
           (when (and (equal "global-map" keymap-name)

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -833,6 +833,22 @@ Examples:
                    finally return new-args))
     (symbol args)))
 
+(defmacro mykie:define-prefix-key (parent-map prefix-key pred &rest mykie-keys)
+  "Make prefix key and register specific key."
+  `(let* ((key (mykie:format-key ,prefix-key))
+          (keyname (key-description key))
+          (prefix-map (intern (format "mykie:%s-prefix-%s"
+                                      (quote ,parent-map) keyname)))
+          (parent (symbol-value (quote ,parent-map))))
+     (define-prefix-command prefix-map)
+     (mykie:set-keys-core prefix-map (quote ,mykie-keys))
+     (fset prefix-map
+           `(lambda ()
+              (interactive)
+              (set-transient-map ,prefix-map ,,pred)))
+     (define-key parent key prefix-map)))
+(put 'mykie:define-prefix-key 'lisp-indent-function 2)
+
 (defmacro mykie:combined-command (&rest args)
   "This macro return lambda form with `mykie'.
 So you can register keybind like this:

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -311,7 +311,7 @@ The MODE is mode name's symbol such as 'emacs-lisp-mode."
                    (member mode mykie:minor-mode-ignore-list)))
        (attach-func
         (lambda (mykie-global-keys)
-          (loop with keymap-name = (concat (symbol-name mode) "-map")
+          (loop with keymap-name = (format "%s-map" mode)
                 with keymap      = (symbol-value (intern keymap-name))
                 for key in mykie-global-keys
                 for args = (funcall (lookup-key global-map key) t)
@@ -362,9 +362,6 @@ If return value is non-nil, then save the value to `mykie:current-thing'."
   (mykie:aif (thing-at-point thing)
       (setq mykie:current-thing it)))
 
-(defun mykie:concat-prefix (state prefix)
-  (intern (concat ":" prefix (symbol-name state))))
-
 (defun mykie:get-comment/string-state ()
   "Return :comment if current point is comment or string face."
   (when (nth 8 (save-excursion (syntax-ppss
@@ -389,7 +386,7 @@ condition if you specified prefix(whether current-prefix-arg or region
 active).
 The major-mode replaced to `major-mode' name.
 You can specify \"C-u&\" or \"region&\" to the PREFIX."
-  (lexical-let ((keyword (mykie:concat-prefix major-mode prefix)))
+  (lexical-let ((keyword (intern (format ":%s%s" (or prefix "") major-mode))))
     (when (plist-get mykie:current-args keyword)
       keyword)))
 
@@ -405,8 +402,8 @@ call `mykie' function."
                 ((times (mykie:get-C-u-times)))
               (if (= 1 times)
                   :C-u
-                (intern (concat ":C-u*" (number-to-string times))))))
-    (number (intern (concat ":M-" (number-to-string current-prefix-arg))))))
+                (intern (format ":C-u*%i" times)))))
+    (number (intern (format ":M-%i" current-prefix-arg)))))
 
 ;; Backward compatibility
 (defalias 'mykie:get-C-u-keyword 'mykie:get-prefix-arg-state)

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -782,14 +782,20 @@ Examples:
        (keymap-sym (cdr pair))
        (set-key
         (lambda (key-and-prop &optional keymap-name keymap)
-          (let
+          (let*
               ((key (car key-and-prop))
                (property
                 (mykie:parse-parenthesized-syntax (cdr key-and-prop))))
             (cl-case order
               (with-self-key
                (mykie:define-key-with-self-key-core key property))
-              (t (mykie:define-key-core keymap-name keymap key property))))))
+              (t ; apply defining function without :default
+               (when (not (or (member :default property)
+                              (member t property)))
+                 (cl-case (length property)
+                   (1 (setq property (append '(:default) property)))
+                   (2 (setq property (append '(:default) `(,property))))))
+               (mykie:define-key-core keymap-name keymap key property))))))
        (set-keys
         (lambda ()
           (cl-loop with last = (1- (length args))

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -777,8 +777,7 @@ Examples:
               (t (mykie:define-key-core keymap-name keymap key property))))))
        (set-keys
         (lambda ()
-          (cl-loop with key-and-prop = '()
-                   with last = (1- (length args))
+          (cl-loop with last = (1- (length args))
                    with keymap-name = (symbol-name keymap-sym)
                    with keymap = (symbol-value keymap-sym)
                    for i from 0 to last
@@ -797,8 +796,7 @@ Examples:
 
 (defun mykie:parse-parenthesized-syntax (args)
   (cl-typecase (car args)
-    (list (cl-loop with new-args
-                   for (keyword . function) in args
+    (list (cl-loop for (keyword . function) in args
                    collect keyword into new-args
                    if (listp function)
                    collect `(progn ,@function) into new-args

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -820,13 +820,13 @@ So you can register keybind like this:
      (mykie:core (quote ,args))))
 
 (defadvice mykie:combined-command
-  (around ad-parse-parenthesized activate)
+    (around ad-parse-parenthesized activate)
   "Parse args to convert parenthesized-syntax if it was needed."
   (ad-set-args 0 (mykie:parse-parenthesized-syntax (ad-get-args 0)))
   ad-do-it)
 
 (defadvice mykie
-  (around mykie:parse-parenthesized-syntax activate)
+    (around mykie:parse-parenthesized-syntax activate)
   "Parse args to convert parenthesized-syntax if it was needed."
   (ad-set-args 0 (mykie:parse-parenthesized-syntax (ad-get-args 0)))
   ad-do-it)

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -664,9 +664,7 @@ Example:
           (when (and (equal "global-map" keymap-name)
                      (< 1 (length (key-description key))))
             (add-to-list 'mykie:global-keys key))
-          (fset sym (lambda (&optional get-args)
-                      (interactive)
-                      (if get-args args (funcall 'mykie:core args))))
+          (fset sym (mykie:make-mykie-function args))
           (define-key keymap key sym)
           (mykie:aif (plist-get args :clone)
               (progn
@@ -676,6 +674,11 @@ Example:
                 (mykie:clone-key
                  it (mykie:replace-property args `(:key-info (,it . "global-map")))
                  '(:default self-insert-command)))))))))
+
+(defun mykie:make-mykie-function (args)
+  (lambda (&optional get-args)
+    (interactive)
+    (if get-args args (funcall 'mykie:core args))))
 
 (defun mykie:clone-key (key args default-keyword-and-func &optional keymap-info)
   (let

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -5,7 +5,7 @@
 ;; Author: Yuta Yamada <cokesboy"at"gmail.com>
 ;; URL: https://github.com/yuutayamada/mykie-el
 ;; Version: 0.2.1
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
 ;; Keywords: Emacs, configuration, keybind
 
 ;;; License:

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -5,6 +5,7 @@
 ;; Author: Yuta Yamada <cokesboy"at"gmail.com>
 ;; URL: https://github.com/yuutayamada/mykie-el
 ;; Version: 0.2.1
+;; Package-Requires: ((emacs "24.1"))
 ;; Keywords: Emacs, configuration, keybind
 
 ;;; License:

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -817,15 +817,19 @@ Examples:
     (funcall set-keys)))
 
 (defun mykie:format-property (order property)
-  (mykie:parse-parenthesized-syntax
-   (if (eq order 'with-self-key)
-       property
-     (if (not (or (member :default property)
-                  (member t property)))
-         (cl-case (length property)
-           (1 (append '(:default) property))
-           (2 (append '(:default) `(,property))))
-       property))))
+  (let ((props (if (condition-case _err
+                       (keywordp (caar property))
+                     (error nil))
+                   (mykie:parse-parenthesized-syntax property)
+                 property)))
+    (if (eq order 'with-self-key)
+        props
+      (if (not (or (member :default props)
+                   (member t props)))
+          (cl-case (length props)
+            (1 (append '(:default) props))
+            (2 (append '(:default) `(,props))))
+        props))))
 
 (defun mykie:parse-parenthesized-syntax (args)
   (cl-typecase (car args)

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -5,7 +5,7 @@
 ;; Author: Yuta Yamada <cokesboy"at"gmail.com>
 ;; URL: https://github.com/yuutayamada/mykie-el
 ;; Version: 0.2.1
-;; Package-Requires: ((emacs "24.1"))
+;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: Emacs, configuration, keybind
 
 ;;; License:

--- a/lisp/mykie.el
+++ b/lisp/mykie.el
@@ -4,7 +4,7 @@
 
 ;; Author: Yuta Yamada <cokesboy"at"gmail.com>
 ;; URL: https://github.com/yuutayamada/mykie-el
-;; Version: 0.2.1
+;; Version: 0.3.0
 ;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
 ;; Keywords: Emacs, configuration, keybind
 

--- a/test/mykie-test.el
+++ b/test/mykie-test.el
@@ -109,6 +109,21 @@
   (cmds-do '(default C-u) global-map "C-9")
   (cmds-do '(default C-u) global-map "C-1"))
 
+(ert-deftest mykie-set-keys-short-hand ()
+  "`mykie:set-keys' should call function even user doesn't specify
+:default keyword."
+  (mykie:set-keys global-map
+    "C-e" (setq test-result 'default)
+    "H-m" (setq test-result 'default)
+    "S-a" (setq test-result 'default)
+    "A-c" (setq test-result 'default)
+    "M-s" (setq test-result 'default))
+  (cmds-do '(default) global-map "C-e")
+  (cmds-do '(default) global-map "H-m")
+  (cmds-do '(default) global-map "S-a")
+  (cmds-do '(default) global-map "A-c")
+  (cmds-do '(default) global-map "M-s"))
+
 ;; mykie:combined-command
 (ert-deftest mykie-combined-command ()
   (global-set-key (kbd "C-4")

--- a/test/mykie-test.el
+++ b/test/mykie-test.el
@@ -160,3 +160,11 @@
                      (:C-u     (message "")
                                (setq test-result 'C-u)))))
   (cmds-do '(default C-u) global-map "C-3"))
+
+;; Local Variables:
+;; coding: utf-8
+;; mode: emacs-lisp
+;; no-byte-compile: t
+;; End:
+
+;;; mykie-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -18,7 +18,7 @@
     (when test-region-state (set-mark (point)))
     (call-interactively (lookup-key map (kbd key)))
     (case expect
-      (readonly (read-only-mode 0))
+      (readonly (toggle-read-only 0))
       ((url C-u&url)     (should (equal test-url  mykie:current-thing)))
       ((email C-u&email) (should (equal test-mail mykie:current-thing)))
       ((file C-u&file)   (should (equal "./" mykie:current-file))))
@@ -55,7 +55,7 @@
       ((url   C-u&url)   (insert test-url))
       ((email C-u&email) (insert test-mail))
       ((file  C-u&file)  (insert "./"))
-      (readonly (read-only-mode t))
+      (readonly (toggle-read-only t))
       (comment  (emacs-lisp-mode)
                 (insert "\"comment\"")
                 (backward-char 4))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -16,7 +16,7 @@
   (with-temp-buffer
     (test-init expect)
     (when test-region-state (set-mark (point)))
-    (call-interactively (lookup-key map (kbd key)))
+    (call-interactively (lookup-key map (mykie:kbd key)))
     (case expect
       (readonly (toggle-read-only 0))
       ((url C-u&url)     (should (equal test-url  mykie:current-thing)))


### PR DESCRIPTION
Update to version 0.3.0

The summary are:
1. using lexical binding
2. short hand syntax (now you can set mykie:set-keys without :default keyword)
3. new function mykie:define-prefix-key to make prefix keygings with mykilized keys
4. requrie Emacs 24.3 or higher
